### PR TITLE
fix: incorrect counting of consecutive braces

### DIFF
--- a/RefConsolidate.js
+++ b/RefConsolidate.js
@@ -585,15 +585,20 @@ var refcon = {
 		// Go through the textPart and find the template's end code '}}'
 		// @todo: could use ProveIt's alternative code here
 		for ( i = 2; i < nextTemplateIndex; i++ ) {
-			if (textPart.charAt(i) === "{" && prevChar === "{")
+			if (textPart.charAt(i) === "{" && prevChar === "{") {
 				++depth;
-			if (textPart.charAt(i) === "}" && prevChar === "}")
+				prevChar = '';  // reset prevChar to avoid double counting for '{{{{'
+			} else if (textPart.charAt(i) === "}" && prevChar === "}") {
 				--depth;
+				prevChar = '';  // reset prevChar to avoid double counting for '}}}}'
+			} else {
+				prevChar = textPart.charAt(i);
+			}
+			
 			if (depth === 0) {
 				templateEndIndex = i + 1;
 				break;
 			}
-			prevChar = textPart.charAt(i);
 		}
 
 		// If templateEndIndex is 0, reference template's ending '}}' is missing in the textPart


### PR DESCRIPTION
Bug spotted in `getTemplateContent` function of `RefConsolidate.js`, where nested braces without spaces (`}}}}`) are incorrectly parsed.

Previously, the function would incorrectly count consecutive closing braces (e.g., `}}}}`) as multiple template closures. This caused premature termination when parsing templates like:
```mediawiki
{{Reflist|refs=
...

<!-- Multiple references grouped together in one <ref> tag -->
<ref name="EXAMPLE_REF_NAME">{{Bulleted list|{{Citation ...}}|{{Citation ...}}|{{Citation ...}}}}</ref>

...
}}
```

The `getTemplateContent` function used to clip the content of `{{Reflist}}` would terminate on `}}}}` since it counts `}}}}` as three `}}`s.

I modified the logic to clear `prevChar` after matching either `{{` or `}}`, preventing the third consecutive brace from being counted as another template marker.

The modified code has been tested in my sandbox.